### PR TITLE
Support for cardano-node 8.7.3

### DIFF
--- a/Dockerfiles/build_env/aarch64/Dockerfile
+++ b/Dockerfiles/build_env/aarch64/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /root
 RUN git clone https://github.com/input-output-hk/libsodium
 
 WORKDIR /root/libsodium
-RUN git checkout 66f017f1
+RUN git checkout a5baeccc5be38dda54dd85eba58fdd929b2b8387
 RUN ./autogen.sh
 RUN ./configure
 RUN make

--- a/Dockerfiles/build_env/aarch64/Dockerfile
+++ b/Dockerfiles/build_env/aarch64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 LABEL name="cardano_env"
 LABEL description="AARCH64 Environment for building Cardano node & tools"
 LABEL maintainer="https://github.com/pascallapointe"
@@ -22,7 +22,7 @@ RUN apt-get install -y libsystemd-dev
 RUN apt-get install -y liblmdb-dev
 RUN apt-get install -y libsodium-dev
 RUN apt-get install -y zlib1g-dev
-RUN apt-get install -y llvm-9
+RUN apt-get install -y llvm-14
 RUN apt-get install -y automake
 RUN apt-get install -y make
 RUN apt-get install -y build-essential
@@ -39,8 +39,8 @@ RUN apt-get install -y autoconf
 RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.20.0/aarch64-linux-ghcup-0.1.20.0
 RUN chmod 500 ghcup
 
-RUN ./ghcup -v --downloader wget install ghc 9.6.3
-RUN ./ghcup set ghc 9.6.3
+RUN ./ghcup -v --downloader wget install ghc 9.6.4
+RUN ./ghcup set ghc 9.6.4
 
 # Install aarch64 cabal 3.10.1.0
 RUN ./ghcup -v --downloader wget install cabal 3.10.1.0

--- a/Dockerfiles/build_env/aarch64/Dockerfile
+++ b/Dockerfiles/build_env/aarch64/Dockerfile
@@ -33,14 +33,14 @@ RUN apt-get install -y libnuma-dev
 RUN apt-get install -y libtool
 RUN apt-get install -y autoconf
 
-# Install aarch64 ghcup-0.1.18.0
-RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.18.0/aarch64-linux-ghcup-0.1.18.0
+# Install aarch64 ghcup-0.1.19.2
+RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.19.2/aarch64-linux-ghcup-0.1.19.2
 RUN chmod 500 ghcup
-RUN ./ghcup -v --downloader wget install ghc 8.10.7
-RUN ./ghcup set ghc 8.10.7
+RUN ./ghcup -v --downloader wget install ghc 9.2.7
+RUN ./ghcup set ghc 9.2.7
 
-# Install aarch64 cabal 3.6.2.0
-RUN ./ghcup -v --downloader wget install cabal 3.6.2.0
+# Install aarch64 cabal 3.10.1.0
+RUN ./ghcup -v --downloader wget install cabal 3.10.1.0
 
 # Install Bitcoin secp256k1 dependency
 RUN git clone https://github.com/bitcoin-core/secp256k1.git

--- a/Dockerfiles/build_env/aarch64/Dockerfile
+++ b/Dockerfiles/build_env/aarch64/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get install -y libgmp-dev
 RUN apt-get install -y libssl-dev
 RUN apt-get install -y libtinfo-dev
 RUN apt-get install -y libsystemd-dev
+RUN apt-get install -y liblmdb-dev
+RUN apt-get install -y libsodium-dev
 RUN apt-get install -y zlib1g-dev
 RUN apt-get install -y llvm-9
 RUN apt-get install -y automake
@@ -34,13 +36,14 @@ RUN apt-get install -y libtool
 RUN apt-get install -y autoconf
 
 # Install aarch64 ghcup-0.1.18.0
-RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.18.0/aarch64-linux-ghcup-0.1.18.0
+RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.20.0/aarch64-linux-ghcup-0.1.20.0
 RUN chmod 500 ghcup
-RUN ./ghcup -v --downloader wget install ghc 8.10.7
-RUN ./ghcup set ghc 8.10.7
 
-# Install aarch64 cabal 3.6.2.0
-RUN ./ghcup -v --downloader wget install cabal 3.6.2.0
+RUN ./ghcup -v --downloader wget install ghc 9.6.3
+RUN ./ghcup set ghc 9.6.3
+
+# Install aarch64 cabal 3.10.1.0
+RUN ./ghcup -v --downloader wget install cabal 3.10.1.0
 
 # Install Bitcoin secp256k1 dependency
 RUN git clone https://github.com/bitcoin-core/secp256k1.git
@@ -63,7 +66,7 @@ WORKDIR /root
 RUN git clone https://github.com/input-output-hk/libsodium
 
 WORKDIR /root/libsodium
-RUN git checkout a5baeccc5be38dda54dd85eba58fdd929b2b8387
+RUN git checkout dbb48cc
 RUN ./autogen.sh
 RUN ./configure
 RUN make
@@ -74,9 +77,22 @@ ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 
 WORKDIR /root
 
+# Install BLST dependencies
+RUN git clone https://github.com/supranational/blst
+WORKDIR /root/blst
+RUN git checkout v0.3.10
+RUN ./build.sh
+COPY files/libblst.pc /usr/local/lib/pkgconfig/libblst.pc
+RUN cp bindings/blst_aux.h bindings/blst.h bindings/blst.hpp /usr/local/include/
+RUN cp libblst.a /usr/local/lib
+RUN chmod u=rw,go=r /usr/local/lib/pkgconfig/libblst.pc /usr/local/include/blst_aux.h /usr/local/include/blst.h /usr/local/include/blst.hpp /usr/local/lib/libblst.a
+
+WORKDIR /root
+
 # Image clean-up
 RUN rm -rf secp256k1
 RUN rm -rf libsodium
+RUN rm -rf blst
 RUN cabal clean
 RUN apt-get autoremove -y
 RUN apt-get clean

--- a/Dockerfiles/build_env/aarch64/Dockerfile
+++ b/Dockerfiles/build_env/aarch64/Dockerfile
@@ -33,14 +33,14 @@ RUN apt-get install -y libnuma-dev
 RUN apt-get install -y libtool
 RUN apt-get install -y autoconf
 
-# Install aarch64 ghcup-0.1.19.2
-RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.19.2/aarch64-linux-ghcup-0.1.19.2
+# Install aarch64 ghcup-0.1.18.0
+RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.18.0/aarch64-linux-ghcup-0.1.18.0
 RUN chmod 500 ghcup
-RUN ./ghcup -v --downloader wget install ghc 9.2.7
-RUN ./ghcup set ghc 9.2.7
+RUN ./ghcup -v --downloader wget install ghc 8.10.7
+RUN ./ghcup set ghc 8.10.7
 
-# Install aarch64 cabal 3.10.1.0
-RUN ./ghcup -v --downloader wget install cabal 3.10.1.0
+# Install aarch64 cabal 3.6.2.0
+RUN ./ghcup -v --downloader wget install cabal 3.6.2.0
 
 # Install Bitcoin secp256k1 dependency
 RUN git clone https://github.com/bitcoin-core/secp256k1.git

--- a/Dockerfiles/build_env/aarch64/files/libblst.pc
+++ b/Dockerfiles/build_env/aarch64/files/libblst.pc
@@ -1,0 +1,11 @@
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libblst
+Description: Multilingual BLS12-381 signature library
+URL: https://github.com/supranational/blst
+Version: 0.3.10
+Cflags: -I${includedir}
+Libs: -L${libdir} -lblst

--- a/Dockerfiles/build_env/x86_64/Dockerfile
+++ b/Dockerfiles/build_env/x86_64/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /root
 RUN git clone https://github.com/input-output-hk/libsodium
 
 WORKDIR /root/libsodium
-RUN git checkout 66f017f1
+RUN git checkout a5baeccc5be38dda54dd85eba58fdd929b2b8387
 RUN ./autogen.sh
 RUN ./configure
 RUN make

--- a/Dockerfiles/build_env/x86_64/Dockerfile
+++ b/Dockerfiles/build_env/x86_64/Dockerfile
@@ -33,14 +33,14 @@ RUN apt-get install -y libnuma-dev
 RUN apt-get install -y libtool
 RUN apt-get install -y autoconf
 
-# Install aarch64 ghcup-0.1.13
-RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.14/x86_64-linux-ghcup-0.1.14
+# Install aarch64 ghcup-0.1.19.2
+RUN wget -O ghcup https://downloads.haskell.org/~ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2
 RUN chmod 500 ghcup
-RUN ./ghcup -v --downloader wget install ghc 8.10.4
-RUN ./ghcup set ghc 8.10.4
+RUN ./ghcup -v --downloader wget install ghc 9.2.7
+RUN ./ghcup set ghc 9.2.7
 
-# Install aarch64 cabal 3.4
-RUN ./ghcup -v --downloader wget install cabal
+# Install aarch64 cabal 3.10.1.0
+RUN ./ghcup -v --downloader wget install cabal 3.10.1.0
 
 # Install Bitcoin secp256k1 dependency
 RUN git clone https://github.com/bitcoin-core/secp256k1.git

--- a/Dockerfiles/db-sync/Dockerfile
+++ b/Dockerfiles/db-sync/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install -y postgresql postgresql-contrib
 # Download cardano-node repository
 ARG RELEASE
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-8.10.7
+ARG GHC_VERSION=ghc-9.2.7
 ARG PGPASSFILE="config/pgpass-mainnet scripts/postgresql-setup.sh --createdb"
 RUN git clone https://github.com/input-output-hk/cardano-db-sync
 WORKDIR /root/cardano-db-sync

--- a/Dockerfiles/db-sync/Dockerfile
+++ b/Dockerfiles/db-sync/Dockerfile
@@ -1,0 +1,83 @@
+FROM cardano_env
+
+LABEL name="cardano_node"
+LABEL description="Cardano node"
+LABEL maintainer="https://github.com/pascallapointe"
+
+WORKDIR /root
+
+# Install base utilities and dependencies
+RUN apt-get update
+RUN apt-get install -y libghc-postgresql-libpq-dev
+RUN apt-get install -y libpq5
+RUN apt-get install -y postgresql postgresql-contrib
+
+# Download cardano-node repository
+ARG RELEASE
+ARG ARCHITECTURE
+ARG GHC_VERSION=ghc-8.10.7
+ARG PGPASSFILE="config/pgpass-mainnet scripts/postgresql-setup.sh --createdb"
+RUN git clone https://github.com/input-output-hk/cardano-db-sync
+WORKDIR /root/cardano-db-sync
+RUN git checkout ${RELEASE}
+
+# Build cardano-node binary
+RUN cabal update
+RUN cabal build cardano-db-sync
+RUN cabal build all
+
+# Create files structure
+RUN mkdir -p /cardano/config /cardano/bin /cardano/ledger-state
+ARG RELEASE_PATH=$RELEASE
+RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-db-sync-${RELEASE_PATH}/build/cardano-db-sync/cardano-db-sync /cardano/bin
+RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-db-tool-${RELEASE_PATH}/x/cardano-db-tool/build/cardano-db-tool/cardano-db-tool /cardano/bin
+
+WORKDIR /root
+RUN mv cardano-db-sync/schema /cardano/.
+
+# Add startup scripts
+COPY files/start.sh /cardano/scripts/start.sh
+COPY files/sleep.sh /cardano/scripts/sleep.sh
+
+# Creating non root user cardano
+RUN useradd -m cardano
+
+# Add permissions
+RUN chown -R cardano:cardano /cardano
+RUN chmod g+s /cardano
+RUN chmod 540 /cardano/scripts/*
+RUN chmod 540 /cardano/bin/*
+
+ENV PATH=/cardano/scripts:/cardano/bin:$PATH
+
+# Image clean-up
+WORKDIR /root
+
+#RUN cabal clean
+RUN rm -rf cardano-db-sync
+RUN rm -rf .cabal .local
+RUN apt-get purge -y apt-utils
+RUN apt-get purge -y git
+RUN apt-get purge -y wget
+RUN apt-get purge -y pkg-config
+RUN apt-get purge -y libgmp-dev
+RUN apt-get purge -y libssl-dev
+RUN apt-get purge -y libtinfo-dev
+RUN apt-get purge -y libsystemd-dev
+RUN apt-get purge -y zlib1g-dev
+RUN apt-get purge -y llvm
+RUN apt-get purge -y build-essential
+RUN apt-get purge -y libffi-dev
+RUN apt-get purge -y make
+RUN apt-get purge -y g++
+
+RUN apt-get autoremove -y
+RUN apt-get clean
+RUN apt-get autoclean
+
+# Switch user
+USER cardano:cardano
+WORKDIR /cardano
+
+CMD ["/bin/bash", "-c", "start.sh"]
+

--- a/Dockerfiles/db-sync/Dockerfile
+++ b/Dockerfiles/db-sync/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get install -y postgresql postgresql-contrib
 # Download cardano-node repository
 ARG RELEASE
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-9.2.7
+ARG GHC_VERSION=ghc-8.10.7
 ARG PGPASSFILE="config/pgpass-mainnet scripts/postgresql-setup.sh --createdb"
 RUN git clone https://github.com/input-output-hk/cardano-db-sync
 WORKDIR /root/cardano-db-sync

--- a/Dockerfiles/db-sync/files/sleep.sh
+++ b/Dockerfiles/db-sync/files/sleep.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while :; do
+  sleep 300
+done

--- a/Dockerfiles/db-sync/files/start.sh
+++ b/Dockerfiles/db-sync/files/start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+BASE_DIR=/cardano
+SOCKET_PATH=${BASE_DIR}/socket/node.sock
+CONFIG_DIR=${BASE_DIR}/config
+CONFIG=${CONFIG_DIR}/mainnet-config.yaml
+STATE_DIR=${BASE_DIR}/ledger-state
+SCHEMA_DIR=${BASE_DIR}/schema
+
+_term() {
+  echo "Stopping Db-Sync ..."
+  kill -SIGINT $PID
+}
+
+trap _term SIGTERM SIGINT
+
+echo "Starting Db-Sync ..."
+# pg_ctlcluster 12 main start
+cardano-db-sync --config ${CONFIG} --socket-path ${SOCKET_PATH} --state-dir ${STATE_DIR} --schema-dir ${SCHEMA_DIR}
+PID=$!
+wait $PID
+trap - SIGTERM SIGINT
+wait $PID
+sleep 5
+EXIT_STATUS=$?
+
+echo "Exit Status: ${EXIT_STATUS}"
+

--- a/Dockerfiles/monitor/Dockerfile
+++ b/Dockerfiles/monitor/Dockerfile
@@ -37,13 +37,13 @@ RUN chmod 544 /cardano/scripts/start-monitoring.sh
 COPY files/prometheus.yml /cardano/config/prometheus.yml
 
 # Creating non root user cardano
-RUN useradd -m cardano
+#RUN useradd -m cardano
 
 # Add data store folder
 RUN mkdir /cardano/data
 
 # Add permissions
-RUN chown -R cardano:cardano /cardano
+#RUN chown -R cardano:cardano /cardano
 RUN chmod g+s /cardano
 
 # Export executable path
@@ -58,6 +58,6 @@ RUN apt-get autoremove -y
 RUN apt-get clean
 RUN apt-get autoclean
 
-USER cardano:cardano
+#USER cardano:cardano
 
 CMD ["start-monitoring.sh"]

--- a/Dockerfiles/node/Dockerfile
+++ b/Dockerfiles/node/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 # Download cardano-node repository
 ARG RELEASE
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-9.2.7
+ARG GHC_VERSION=ghc-8.10.7
 RUN git clone https://github.com/input-output-hk/cardano-node
 WORKDIR /root/cardano-node
 RUN git checkout ${RELEASE}
@@ -40,10 +40,10 @@ RUN apt-get install -y curl
 COPY files/topologyUpdater.sh /cardano/scripts/topologyUpdater.sh
 
 # Creating non root user cardano
-RUN useradd -m cardano
+# RUN useradd -m cardano
 
 # Add permissions
-RUN chown -R cardano:cardano /cardano
+# RUN chown -R cardano:cardano /cardano
 RUN chmod g+s /cardano
 RUN chmod 540 /cardano/scripts/*
 RUN chmod 540 /cardano/bin/*
@@ -77,7 +77,7 @@ RUN apt-get clean
 RUN apt-get autoclean
 
 # Switch user
-USER cardano:cardano
+# USER cardano:cardano
 WORKDIR /cardano
 
 CMD ["/bin/bash", "-c", "start-relay.sh"]

--- a/Dockerfiles/node/Dockerfile
+++ b/Dockerfiles/node/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 # Download cardano-node repository
 ARG RELEASE
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-8.10.7
+ARG GHC_VERSION=ghc-9.2.7
 RUN git clone https://github.com/input-output-hk/cardano-node
 WORKDIR /root/cardano-node
 RUN git checkout ${RELEASE}

--- a/Dockerfiles/node/Dockerfile
+++ b/Dockerfiles/node/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 # Download cardano-node repository
 ARG NODE_TAG
 ARG ARCHITECTURE
-RUN git clone https://github.com/input-output-hk/cardano-node
+RUN git clone https://github.com/IntersectMBO/cardano-node.git
 WORKDIR /root/cardano-node
 RUN git checkout ${NODE_TAG}
 RUN git submodule update --init --recursive
@@ -24,7 +24,7 @@ RUN cabal build cardano-node cardano-cli
 
 # Create files structure
 RUN mkdir -p /cardano/config /cardano/bin /cardano/db /cardano/socket /cardano/scripts
-ARG GHC_VERSION=ghc-9.6.3
+ARG GHC_VERSION=ghc-9.6.4
 ARG NODE_PATH=$NODE_TAG
 ARG CLI_PATH
 #WORKDIR /root/cardano-node

--- a/Dockerfiles/node/Dockerfile
+++ b/Dockerfiles/node/Dockerfile
@@ -7,12 +7,11 @@ LABEL maintainer="https://github.com/pascallapointe"
 WORKDIR /root
 
 # Download cardano-node repository
-ARG RELEASE
+ARG NODE_TAG
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-8.10.7
 RUN git clone https://github.com/input-output-hk/cardano-node
 WORKDIR /root/cardano-node
-RUN git checkout ${RELEASE}
+RUN git checkout ${NODE_TAG}
 RUN git submodule update --init --recursive
 
 # Add cabal config files
@@ -21,13 +20,17 @@ COPY files/cabal.project.local /root/cardano-node/cabal.project.local
 # Build cardano-node binary
 RUN cabal update
 RUN cabal user-config update
-RUN cabal build all
+RUN cabal build cardano-node cardano-cli
 
 # Create files structure
 RUN mkdir -p /cardano/config /cardano/bin /cardano/db /cardano/socket /cardano/scripts
-ARG RELEASE_PATH=$RELEASE
-RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-node-${RELEASE_PATH}/x/cardano-node/build/cardano-node/cardano-node /cardano/bin
-RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-cli-${RELEASE_PATH}/x/cardano-cli/build/cardano-cli/cardano-cli /cardano/bin
+ARG GHC_VERSION=ghc-9.6.3
+ARG NODE_PATH=$NODE_TAG
+ARG CLI_PATH
+#WORKDIR /root/cardano-node
+RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-node-${NODE_PATH}/x/cardano-node/build/cardano-node/cardano-node /cardano/bin
+#WORKDIR /root/cardano-cli
+RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-cli-${CLI_PATH}/x/cardano-cli/build/cardano-cli/cardano-cli /cardano/bin
 
 # Add startup scripts
 COPY files/start-relay.sh /cardano/scripts/start-relay.sh
@@ -65,6 +68,7 @@ RUN apt-get purge -y libgmp-dev
 RUN apt-get purge -y libssl-dev
 RUN apt-get purge -y libtinfo-dev
 RUN apt-get purge -y libsystemd-dev
+RUN apt-get purge -y liblmdb-dev
 RUN apt-get purge -y zlib1g-dev
 RUN apt-get purge -y llvm
 RUN apt-get purge -y build-essential

--- a/Dockerfiles/node/Dockerfile
+++ b/Dockerfiles/node/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get purge -y libtinfo-dev
 RUN apt-get purge -y libsystemd-dev
 RUN apt-get purge -y liblmdb-dev
 RUN apt-get purge -y zlib1g-dev
-RUN apt-get purge -y llvm
+RUN apt-get purge -y llvm-14
 RUN apt-get purge -y build-essential
 RUN apt-get purge -y libffi-dev
 RUN apt-get purge -y make

--- a/Dockerfiles/submit/Dockerfile
+++ b/Dockerfiles/submit/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 # Download cardano-node repository
 ARG RELEASE
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-8.10.7
+ARG GHC_VERSION=ghc-9.2.7
 RUN git clone https://github.com/input-output-hk/cardano-node
 WORKDIR /root/cardano-node
 RUN git checkout ${RELEASE}

--- a/Dockerfiles/submit/Dockerfile
+++ b/Dockerfiles/submit/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get purge -y libssl-dev
 RUN apt-get purge -y libtinfo-dev
 RUN apt-get purge -y libsystemd-dev
 RUN apt-get purge -y zlib1g-dev
-RUN apt-get purge -y llvm
+RUN apt-get purge -y llvm-14
 RUN apt-get purge -y build-essential
 RUN apt-get purge -y libffi-dev
 RUN apt-get purge -y make

--- a/Dockerfiles/submit/Dockerfile
+++ b/Dockerfiles/submit/Dockerfile
@@ -7,12 +7,11 @@ LABEL maintainer="https://github.com/pascallapointe"
 WORKDIR /root
 
 # Download cardano-node repository
-ARG RELEASE
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-8.10.7
+ARG NODE_TAG
 RUN git clone https://github.com/input-output-hk/cardano-node
 WORKDIR /root/cardano-node
-RUN git checkout ${RELEASE}
+RUN git checkout ${NODE_TAG}
 RUN git submodule update --init --recursive
 
 # Add cabal config files
@@ -25,8 +24,9 @@ RUN cabal build exe:cardano-submit-api
 
 # Create files structure
 RUN mkdir -p /cardano/config /cardano/bin /cardano/db /cardano/socket /cardano/scripts
-ARG RELEASE_PATH=$RELEASE
-RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-submit-api-${RELEASE_PATH}/x/cardano-submit-api/build/cardano-submit-api/cardano-submit-api /cardano/bin
+ARG GHC_VERSION=ghc-9.6.4
+ARG API_VERSION
+RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-submit-api-${API_VERSION}/x/cardano-submit-api/build/cardano-submit-api/cardano-submit-api /cardano/bin
 
 # Add startup scripts
 COPY files/start.sh /cardano/scripts/start.sh

--- a/Dockerfiles/submit/Dockerfile
+++ b/Dockerfiles/submit/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 # Download cardano-node repository
 ARG RELEASE
 ARG ARCHITECTURE
-ARG GHC_VERSION=ghc-9.2.7
+ARG GHC_VERSION=ghc-8.10.7
 RUN git clone https://github.com/input-output-hk/cardano-node
 WORKDIR /root/cardano-node
 RUN git checkout ${RELEASE}
@@ -32,10 +32,10 @@ RUN cp -p dist-newstyle/build/${ARCHITECTURE}-linux/${GHC_VERSION}/cardano-submi
 COPY files/start.sh /cardano/scripts/start.sh
 
 # Creating non root user cardano
-RUN useradd -m cardano
+#RUN useradd -m cardano
 
 # Add permissions
-RUN chown -R cardano:cardano /cardano
+#RUN chown -R cardano:cardano /cardano
 RUN chmod g+s /cardano
 RUN chmod 540 /cardano/scripts/*
 RUN chmod 540 /cardano/bin/*
@@ -68,7 +68,7 @@ RUN apt-get clean
 RUN apt-get autoclean
 
 # Switch user
-USER cardano:cardano
+#USER cardano:cardano
 WORKDIR /cardano
 
 CMD ["/bin/bash", "-c", "start.sh"]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ First, you need to build all required images:
             --build-arg RELEASE_PATH=${RELEASE_PATH} \
             -t cardano_submit:latest Dockerfiles/submit
 
-6. Tag your image with the **latest** tag:
+6. The DB-Sync image:
+
+        docker build \
+            --build-arg ARCHITECTURE=${ARCHITECTURE} \
+            --build-arg RELEASE=${VERSION_NUMBER} \
+            -t cardano_db_sync:${VERSION_NUMBER} Dockerfiles/db-sync
+
+7. Tag your image with the **latest** tag:
 
         docker tag cardano_node:${VERSION_NUMBER} cardano_node:latest
 
@@ -163,7 +170,6 @@ following command:
 
 - [How get peers with Topology Updater](Docs/topology.md)
 - [Monitoring with Grafana](Docs/monitoring.md)
-- [Installation of db-sync & graphql](../pool-monitor/Docs/db-sync.md)
 - [Dynamic DNS support](Docs/dynamic_dns.md)
 - [Limit containers memory usage](Docs/memory_limit.md)
 - [Manually creating the containers](Docs/standalone-containers.md)

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Thanks to everyone behind `topology updater` from **cardano-community repository
 
 #### !!! Notes !!!
 
-* GHC version: 8.10.4
+* GHC version: 9.2.7
 
-* Cabal version: 3.4
+* Cabal version: 3.10.1
 
 ### Building from source 
 

--- a/README.md
+++ b/README.md
@@ -38,20 +38,24 @@ First, you need to build all required images:
 
     ** Tip: _Add `--no-cache` to rebuild from scratch_ **
 
-3. Set the version variable (Set the right release VERSION_NUMBER, ie: `1.19.0`)
+3. Set the version variable (Set the right release TAG, ie: `1.19.0`)
 
-        VERSION_NUMBER=<VERSION_NUMBER>
+        NODE_TAG=<VERSION_TAG>
 
-4. The node image:
+4. Set the output path if different from TAG (_CLI version now differ from node version_)
+
+        NODE_PATH=<PATH>
+        CLI_PATH=<PATH>
+
+5. The node image:
 
         docker build \
             --build-arg ARCHITECTURE=${ARCHITECTURE} \
-            --build-arg RELEASE=${VERSION_NUMBER} \
+            --build-arg NODE_TAG=${NODE_TAG} \
+            --build-arg CLI_PATH=${CLI_PATH} \
             -t cardano_node:${VERSION_NUMBER} Dockerfiles/node
 
-    ** Tips: _Add `--build-arg RELEASE_PATH=1.3x.x` if the node version differ from the git tag._
-
-5. The submit api image:
+6. The submit api image:
 
         RELEASE_PATH=<Submit API version, see cardano-submit-api.cabal file>
 
@@ -61,14 +65,14 @@ First, you need to build all required images:
             --build-arg RELEASE_PATH=${RELEASE_PATH} \
             -t cardano_submit:latest Dockerfiles/submit
 
-6. The DB-Sync image:
+7. The DB-Sync image:
 
         docker build \
             --build-arg ARCHITECTURE=${ARCHITECTURE} \
             --build-arg RELEASE=${VERSION_NUMBER} \
             -t cardano_db_sync:${VERSION_NUMBER} Dockerfiles/db-sync
 
-7. Tag your image with the **latest** tag:
+8. Tag your image with the **latest** tag:
 
         docker tag cardano_node:${VERSION_NUMBER} cardano_node:latest
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Thanks to everyone behind `topology updater` from **cardano-community repository
 
 #### !!! Notes !!!
 
-* GHC version: 9.2.7
-
-* Cabal version: 3.10.1
+* **GHC** version: **9.6.4**
+* **Cabal** version: **3.10.1.0**
+* Supported **cardano-node** version: **8.7.3**
+* Supported **cardano-cli** version: **8.17.0.0**
+* Supported **cardano-submit-api** version: **3.2.1**
 
 ### Building from source 
 
@@ -27,54 +29,74 @@ I've written a Dockerfile that simplify the process.
 First, you need to build all required images:
   
 1. Set the architecture variable to your requirement (Only x86/amd64 and aarch64 supported):
-  
-        ARCHITECTURE=<PROCESSOR_ARCHITECTURE(x86_64 or aarch64)>
+
+    ```bash 
+    ARCHITECTURE=<PROCESSOR_ARCHITECTURE(x86_64 or aarch64)>
+    ```    
         
 2. The Cardano sources image:
-        
-        docker build \
-            -t cardano_env:latest \
-            ./Dockerfiles/build_env/${ARCHITECTURE}
 
+   ```bash
+   docker build \
+      -t cardano_env:latest \
+      ./Dockerfiles/build_env/${ARCHITECTURE}
+
+   ``` 
     ** Tip: _Add `--no-cache` to rebuild from scratch_ **
+
 
 3. Set the version variable (Set the right release TAG, ie: `1.19.0`)
 
-        NODE_TAG=<VERSION_TAG>
+   ```bash
+   NODE_TAG=<VERSION_TAG>
+   ```
 
 4. Set the output path if different from TAG (_CLI version now differ from node version_)
 
-        NODE_PATH=<PATH>
-        CLI_PATH=<PATH>
+   ```bash
+   # MANDATORY
+   CLI_PATH=<PATH>
+   
+   # OPTIONAL / IF REQUIRED
+   NODE_PATH=<PATH>
+   ```      
 
 5. The node image:
 
-        docker build \
-            --build-arg ARCHITECTURE=${ARCHITECTURE} \
-            --build-arg NODE_TAG=${NODE_TAG} \
-            --build-arg CLI_PATH=${CLI_PATH} \
-            -t cardano_node:${VERSION_NUMBER} Dockerfiles/node
+   ```bash
+   docker build \
+      --build-arg ARCHITECTURE=${ARCHITECTURE} \
+      --build-arg NODE_TAG=${NODE_TAG} \
+      --build-arg CLI_PATH=${CLI_PATH} \
+      -t cardano_node:${NODE_TAG} Dockerfiles/node
+   ```
 
 6. The submit api image:
 
-        RELEASE_PATH=<Submit API version, see cardano-submit-api.cabal file>
-
-        docker build \
-            --build-arg ARCHITECTURE=${ARCHITECTURE} \
-            --build-arg RELEASE=${VERSION_NUMBER} \
-            --build-arg RELEASE_PATH=${RELEASE_PATH} \
-            -t cardano_submit:latest Dockerfiles/submit
+   ```bash
+   API_VERSION=<Submit API version, see cardano-submit-api.cabal file>
+   
+   docker build \
+      --build-arg ARCHITECTURE=${ARCHITECTURE} \
+      --build-arg NODE_TAG=${NODE_TAG} \
+      --build-arg API_VERSION=${API_VERSION} \
+      -t cardano_submit:latest Dockerfiles/submit
+   ```
 
 7. The DB-Sync image:
 
-        docker build \
-            --build-arg ARCHITECTURE=${ARCHITECTURE} \
-            --build-arg RELEASE=${VERSION_NUMBER} \
-            -t cardano_db_sync:${VERSION_NUMBER} Dockerfiles/db-sync
+   ```bash
+   docker build \
+      --build-arg ARCHITECTURE=${ARCHITECTURE} \
+      --build-arg RELEASE=${VERSION_NUMBER} \
+      -t cardano_db_sync:${VERSION_NUMBER} Dockerfiles/db-sync
+   ```
 
 8. Tag your image with the **latest** tag:
 
-        docker tag cardano_node:${VERSION_NUMBER} cardano_node:latest
+   ```bash
+   docker tag cardano_node:${VERSION_NUMBER} cardano_node:latest
+   ```
 
 ### Folder structure
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -148,10 +148,6 @@ services:
     container_name: cardano-monitor
     image: cardano_monitor:latest
     command: ["start-monitoring.sh"]
-    depends_on:
-      - cardano-relay1
-      - cardano-relay2
-      - cardano-bp
     volumes:
       - type: volume
         source: prometheus-db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,13 @@ services:
     restart: unless-stopped
     stop_signal: SIGINT
     stop_grace_period: 10s
+    healthcheck:
+      # Ping the EKG port to see if it responds.
+      # Assuming if EKG isn't up then the rest of cardano-node isn't either.
+      test: [ "CMD-SHELL", "curl -H \"Accept: application/json\" -f 127.0.0.1:12788 || exit 1" ]
+      interval: 60s
+      timeout: 10s
+      retries: 5
     logging:
       driver: "json-file"
       options:
@@ -74,6 +81,13 @@ services:
     restart: unless-stopped
     stop_signal: SIGINT
     stop_grace_period: 10s
+    healthcheck:
+      # Ping the EKG port to see if it responds.
+      # Assuming if EKG isn't up then the rest of cardano-node isn't either.
+      test: [ "CMD-SHELL", "curl -H \"Accept: application/json\" -f 127.0.0.1:12788 || exit 1" ]
+      interval: 60s
+      timeout: 10s
+      retries: 5
     logging:
       driver: "json-file"
       options:
@@ -112,6 +126,13 @@ services:
     restart: unless-stopped
     stop_signal: SIGINT
     stop_grace_period: 10s
+    healthcheck:
+      # Ping the EKG port to see if it responds.
+      # Assuming if EKG isn't up then the rest of cardano-node isn't either.
+      test: [ "CMD-SHELL", "curl -H \"Accept: application/json\" -f 127.0.0.1:12788 || exit 1" ]
+      interval: 60s
+      timeout: 10s
+      retries: 5
     logging:
       driver: "json-file"
       options:
@@ -142,7 +163,7 @@ services:
       - "3200:3200"
     networks:
       cardano:
-    restart: on-failure
+    restart: unless-stopped
     stop_grace_period: 5s
     logging:
       driver: "json-file"
@@ -173,8 +194,89 @@ services:
         max-size: "200k"
         max-file: "10"
 
+  cardano-db-sync:
+    container_name: db-sync
+    image: cardano_db_sync:13.1.0.2
+    environment:
+      PGPASSFILE: '/cardano/config/pgpass-mainnet'
+    #command: ["/bin/bash", "-c", "start.sh"]
+    command: ["/bin/bash", "-c", "sleep.sh"]   # Used for maintenance purpose
+    depends_on:
+      # Depend on both services to be healthy before starting.
+      cardano-relay1:
+        condition: service_healthy
+      cardano-postgres:
+        condition: service_healthy
+    volumes:
+      - type: bind
+        source: ./db-sync/config
+        target: /cardano/config
+        read_only: true
+      - type: bind
+        source: ./relay1/socket
+        target: /cardano/socket
+      - type: volume
+        source: db-sync-ledger
+        target: /cardano/ledger-state
+    networks:
+      db-sync:
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
+
+  cardano-postgres:
+    container_name: cardano-postgres
+    image: postgres:11.18-alpine
+    environment:
+      - POSTGRES_LOGGING=true
+      - POSTGRES_DB_FILE=/run/secrets/postgres_db
+      - POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+      - POSTGRES_USER_FILE=/run/secrets/postgres_user
+    secrets:
+      - postgres_password
+      - postgres_user
+      - postgres_db
+    command: ${POSTGRES_ARGS:--c maintenance_work_mem=1GB -c max_parallel_maintenance_workers=4}
+    ports:
+      - "5433:5432"
+    networks:
+      db-sync:
+        aliases:
+          - postgres
+    volumes:
+      - type: volume
+        source: postgres
+        target: /var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      # Use pg_isready to check postgres is running. Substitute different
+      # user `postgres` if you've setup differently to config/pgpass-mainnet
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "200k"
+        max-file: "10"
+
 volumes:
   prometheus-db:
+  postgres:
+  db-sync-ledger:
 
 networks:
   cardano:
+  db-sync:
+
+secrets:
+  postgres_db:
+    file: ./secrets/postgres_db
+  postgres_password:
+    file: ./secrets/postgres_password
+  postgres_user:
+    file: ./secrets/postgres_user


### PR DESCRIPTION
- GHC updated to version 9.6.4
- LLVM updated to version 14
- Updated docs
- cardano-cli version branched from cardano-node version number
- Cabal build all doesn't work anymore, explicitly target item to build